### PR TITLE
Fix econnreset error crash from certain node client versions

### DIFF
--- a/src/RemoteInterface.js
+++ b/src/RemoteInterface.js
@@ -20,11 +20,17 @@ class RemoteInterface {
   }
 
   launchServer() {
-    this.server = net.createServer()
+    this.server = net.createServer((socket) => {
+      // Important: This error handler  is different than the one below! - KV
+      socket.on('error', (err) => {
+        // ignore errors! - Without this callback, we can get a ECONNRESET error that crashes the server - KV
+      })
+    })
       .on('connection', this.handleNewClient.bind(this))
       .on('error', (err) => {
         // handle errors here
-        throw err
+        console.log('Error: ', err);
+        // throw err
       })
       .listen(PORT, () => {
         console.log('opened server on', this.server.address())


### PR DESCRIPTION
Add additional error handler for socket error, which as it turns out, is different than server error handler. 

Huge thank you to @gary-jipp for helping troubleshoot this!!